### PR TITLE
docs: link docs pages to source repos in atriva-ai org

### DIFF
--- a/src/content/docs/ai-inference/openvino/index.md
+++ b/src/content/docs/ai-inference/openvino/index.md
@@ -3,6 +3,7 @@ title: OpenVINO Overview
 order: 30
 ---
 
+> **Source Code:** [`atriva-ai/ai-inference-ov`](https://github.com/atriva-ai/ai-inference-ov) — contributions welcome via the [community hub](https://github.com/atriva-ai-community/community).
 
 This is a FastAPI-based AI API that leverages **OpenVINO** for optimized deep learning inference.  
 It provides a RESTful interface for running AI models, such as object detection and image classification.
@@ -56,8 +57,8 @@ This section covers everything you need to get the Atriva AI API up and running.
 
 #### **1️⃣ Clone the Repository**
 ```sh
-git clone https://github.com/atriva-ai/atriva-ai-openvino.git
-cd atriva-ai-openvino
+git clone https://github.com/atriva-ai/ai-inference-ov.git
+cd ai-inference-ov
 ```
 
 #### **2️⃣ Create a Virtual Environment**

--- a/src/content/docs/core-api/index.md
+++ b/src/content/docs/core-api/index.md
@@ -3,6 +3,7 @@ title: Atriva Core API
 order: 30
 ---
 
+> **Source Code:** [`atriva-ai/atriva-ai-platform-backend`](https://github.com/atriva-ai/atriva-ai-platform-backend) — contributions welcome via the [community hub](https://github.com/atriva-ai-community/community).
 
 Atriva exposes consistent APIs across applications.
 

--- a/src/content/docs/video-pipeline/ffmpeg-x86/index.md
+++ b/src/content/docs/video-pipeline/ffmpeg-x86/index.md
@@ -3,6 +3,8 @@ title: Atriva Video Pipeline API Service - FFMPEG x86
 order: 11
 ---
 
+> **Source Code:** [`atriva-ai/video-pipeline-ffmpeg-x86`](https://github.com/atriva-ai/video-pipeline-ffmpeg-x86) — contributions welcome via the [community hub](https://github.com/atriva-ai-community/community).
+
 ## Overview
 
 The **Atriva Video Pipeline API Service** is a containerized microservice that provides FFmpeg-based video processing capabilities for the Atriva AI platform. This service is specifically built for **x86 architectures** and serves as a critical component in the video processing pipeline, decoding video streams and extracting frames for downstream AI inference services.


### PR DESCRIPTION
## Summary

- Adds a "Source Code" callout to three docs pages, linking readers directly to the implementation repos:
  - `/docs/ai-inference/openvino` → [`atriva-ai/ai-inference-ov`](https://github.com/atriva-ai/ai-inference-ov)
  - `/docs/video-pipeline/ffmpeg-x86` → [`atriva-ai/video-pipeline-ffmpeg-x86`](https://github.com/atriva-ai/video-pipeline-ffmpeg-x86)
  - `/docs/core-api` → [`atriva-ai/atriva-ai-platform-backend`](https://github.com/atriva-ai/atriva-ai-platform-backend)
- Fixes incorrect clone URL in OpenVINO docs (`atriva-ai-openvino` → `ai-inference-ov`)

## Why

Closes the loop between the docs site and the open-source repos — anyone reading the docs can now find the code and the community contribution path in one click.

## Test plan

- [ ] Visit `/docs/ai-inference/openvino` — source code callout visible with correct link
- [ ] Visit `/docs/video-pipeline/ffmpeg-x86` — source code callout visible
- [ ] Visit `/docs/core-api` — source code callout visible
- [ ] Clone URL in OpenVINO docs resolves to correct repo
- [ ] `npm run build` — clean build

🤖 Generated with [Claude Code](https://claude.ai/claude-code)