### PR TITLE
feat: restructure homepage for multi-audience clarity

### DIFF
--- a/src/components/BusinessModel.astro
+++ b/src/components/BusinessModel.astro
@@ -26,7 +26,7 @@ const models = [
 ];
 ---
 
-<section class="relative py-20 md:py-24 bg-slate-50">
+<section class="relative py-20 md:py-24 bg-white">
   <div class="container max-w-screen-xl mx-auto px-4">
     <!-- Header -->
     <div class="text-center max-w-3xl mx-auto mb-16">
@@ -35,28 +35,28 @@ const models = [
         Open Source Business Model
       </div>
       <h2 class="text-4xl lg:text-5xl font-bold lg:tracking-tight text-slate-900">
-        Build Your Business on Atriva
+        Grow the Edge AI Ecosystem on Atriva
       </h2>
       <p class="text-lg mt-4 text-slate-600">
-        Open source doesn't mean giving up revenue. Choose the model that works for you—from completely free to revenue-sharing partnerships.
+        Whether you're a developer, system integrator, or hardware partner — there's a model here that works for you.
       </p>
     </div>
 
     <!-- Models Grid -->
     <div class="grid md:grid-cols-3 gap-8 max-w-5xl mx-auto">
       {models.map((model, index) => (
-        <div class="relative bg-white rounded-2xl p-8 border border-slate-200 hover:border-[#48A18D]/40 hover:shadow-xl hover:shadow-[#48A18D]/5 transition-all duration-300">
+        <div class="relative bg-[#48A18D] rounded-2xl p-8 transition-all duration-300 hover:bg-[#3b8675] hover:shadow-xl hover:shadow-[#48A18D]/30">
           {/* Icon */}
-          <div class="w-14 h-14 rounded-xl bg-[#48A18D]/10 flex items-center justify-center mb-6">
-            <Icon name={model.icon} class="w-7 h-7 text-[#48A18D]" />
+          <div class="w-14 h-14 rounded-xl bg-white/20 flex items-center justify-center mb-6">
+            <Icon name={model.icon} class="w-7 h-7 text-white" />
           </div>
-          
+
           {/* Content */}
-          <h3 class="text-xl font-bold text-slate-900 mb-3">{model.title}</h3>
-          <p class="text-slate-600 leading-relaxed mb-4">{model.description}</p>
-          
+          <h3 class="text-xl font-bold text-white mb-3">{model.title}</h3>
+          <p class="text-white/80 leading-relaxed mb-4">{model.description}</p>
+
           {/* Highlight badge */}
-          <div class="inline-flex items-center gap-1.5 text-sm font-medium text-[#48A18D]">
+          <div class="inline-flex items-center gap-1.5 text-sm font-medium text-white/90">
             <Icon name="bx:bx-check-circle" class="w-4 h-4" />
             {model.highlight}
           </div>

--- a/src/components/EcosystemPartners.astro
+++ b/src/components/EcosystemPartners.astro
@@ -1,0 +1,29 @@
+---
+import { Icon } from "astro-icon/components";
+---
+
+<section class="relative py-20 md:py-24">
+  <div class="container max-w-screen-xl mx-auto px-4">
+    <div class="max-w-3xl">
+      <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[#48A18D]/10 text-[#48A18D] text-sm font-medium mb-4">
+        <Icon name="bx:bx-network-chart" class="w-4 h-4" />
+        Ecosystem & Partners
+      </div>
+      <h2 class="text-4xl lg:text-5xl font-bold lg:tracking-tight text-slate-900">
+        Built With a Network, Not Just a Platform
+      </h2>
+      <p class="text-lg mt-6 text-slate-600 leading-relaxed">
+        Atriva works with a network of developers, system integrators and end customers, and industrial PC (IPC) hardware partners to deliver edge AI solutions. We help match your project to the right chip and device for your performance and budget — not just whatever's trendiest. We also help international software partners reach customers across borders and languages, bridging delivery teams, hardware partners, and customers who each speak a different "business language."
+      </p>
+      <div class="mt-8">
+        <a
+          href="/contact"
+          class="inline-flex items-center gap-2 px-6 py-3 bg-[#48A18D] hover:bg-[#3b8675] text-white font-semibold rounded-lg transition-colors"
+        >
+          <Icon name="bx:bx-message-rounded-dots" class="w-5 h-5" />
+          Talk to Us About Your Project
+        </a>
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/components/HowItWorks.astro
+++ b/src/components/HowItWorks.astro
@@ -8,13 +8,13 @@ const steps = [
   {
     title: "1. Pick Your Hardware",
     description:
-      "Choose from GPUs, NPUs, SoCs, or edge accelerators. Atriva supports any device.",
+      "Choose from GPUs, NPUs, SoCs, or edge accelerators based on your target market and cost structure. Atriva supports any device.",
     icon: Step1Icon,
   },
   {
     title: "2. Use Prebuilt Containers",
     description:
-      "Deploy optimized inference containers with zero manual setup.",
+      "Focus on your business logic. Reuse prebuilt containers for video ingestion and AI inference as ready-made building blocks — no pipeline plumbing required.",
     icon: Step2Icon,
   },
   {
@@ -37,10 +37,10 @@ const steps = [
 
 <div class="mt-16 md:mt-0">
   <h2 class="text-4xl lg:text-5xl font-bold lg:tracking-tight">
-    How Atriva Works
+    How Atriva Accelerates Development
   </h2>
   <p class="text-lg mt-4 text-slate-600 max-w-4xl">
-    Atriva simplifies the entire Edge AI lifecycle — from setup to deployment to intelligent action.
+    From hardware selection to production deployment — Atriva removes the hard parts so you can ship faster.
   </p>
 
   <div class="grid sm:grid-cols-2 lg:grid-cols-4 mt-16 gap-12">

--- a/src/components/UseCases.astro
+++ b/src/components/UseCases.astro
@@ -55,10 +55,10 @@ const cases = [
   <div class="container max-w-screen-xl mx-auto px-4">
     <div class="mt-16 md:mt-0">
       <h2 class="text-4xl lg:text-5xl font-bold lg:tracking-tight">
-        Use Cases
+        Edge AI in the Real World
       </h2>
       <p class="text-lg mt-4 text-slate-600 max-w-2xl">
-        Real-world applications powered by Atriva's edge-optimized AI stack.
+        From factory floors to retail stores — problems being solved with edge AI today.
       </p>
 
       <div class="grid sm:grid-cols-2 md:grid-cols-3 mt-16 gap-12">

--- a/src/components/WhoWeHelp.astro
+++ b/src/components/WhoWeHelp.astro
@@ -1,0 +1,86 @@
+---
+import { Icon } from "astro-icon/components";
+
+const personas = [
+  {
+    icon: "bx:bx-code-alt",
+    tag: "For Developers",
+    headline: "Find real projects and customers",
+    body: "You have edge AI skills — using your own stack or ours. We connect you with customers who need solutions built and hardware partners who want developers on their platform.",
+    cta: "Find a Project",
+    href: "/contact?type=find-project",
+  },
+  {
+    icon: "bx:bx-buildings",
+    tag: "For Customers & System Integrators",
+    headline: "Tell us your problem. We find the solution.",
+    body: "You don't need to know the technology. Tell us the business outcome you need — we match you to a working solution or the right team to build it.",
+    cta: "Describe Your Need",
+    href: "/contact?type=find-solution",
+    highlight: true,
+  },
+  {
+    icon: "bx:bx-chip",
+    tag: "For Hardware OEMs",
+    headline: "Reach developers who build real products",
+    body: "We work with developers building production edge AI solutions. We help put your hardware in front of the right builders — and the customers who depend on them.",
+    cta: "Explore Partnership",
+    href: "/contact?type=hardware-partner",
+  },
+];
+---
+
+<section class="relative pt-4 pb-20 md:pb-24">
+  <div class="container max-w-screen-xl mx-auto px-4">
+    <div class="text-center max-w-2xl mx-auto mb-14">
+      <h2 class="text-4xl lg:text-5xl font-bold lg:tracking-tight text-slate-900">
+        Who We Help
+      </h2>
+      <p class="text-lg mt-4 text-slate-600">
+        Whether you build software, run a business, or make hardware — we connect you to the right people.
+      </p>
+    </div>
+
+    <div class="grid md:grid-cols-3 gap-8 max-w-6xl mx-auto">
+      {personas.map((p) => (
+        <div class={`relative flex flex-col rounded-2xl p-8 border transition-all duration-300 ${
+          p.highlight
+            ? "bg-[#48A18D] border-[#48A18D] text-white shadow-xl shadow-[#48A18D]/20"
+            : "bg-white border-slate-200 hover:border-[#48A18D]/40 hover:shadow-xl hover:shadow-[#48A18D]/5"
+        }`}>
+          <div class={`w-12 h-12 rounded-xl flex items-center justify-center mb-5 ${
+            p.highlight ? "bg-white/20" : "bg-[#48A18D]/10"
+          }`}>
+            <Icon name={p.icon} class={`w-6 h-6 ${p.highlight ? "text-white" : "text-[#48A18D]"}`} />
+          </div>
+
+          <div class={`text-xs font-semibold uppercase tracking-widest mb-2 ${
+            p.highlight ? "text-white/70" : "text-[#48A18D]"
+          }`}>
+            {p.tag}
+          </div>
+
+          <h3 class={`text-xl font-bold mb-3 ${p.highlight ? "text-white" : "text-slate-900"}`}>
+            {p.headline}
+          </h3>
+
+          <p class={`leading-relaxed mb-8 flex-1 ${p.highlight ? "text-white/85" : "text-slate-600"}`}>
+            {p.body}
+          </p>
+
+          <a
+            href={p.href}
+            class={`inline-flex items-center gap-2 px-5 py-2.5 rounded-lg font-semibold text-sm transition-colors self-start ${
+              p.highlight
+                ? "bg-white text-[#48A18D] hover:bg-slate-100"
+                : "bg-[#48A18D] text-white hover:bg-[#3b8675]"
+            }`}
+          >
+            {p.cta}
+            <Icon name="bx:bx-right-arrow-alt" class="w-4 h-4" />
+          </a>
+        </div>
+      ))}
+    </div>
+  </div>
+</section>

--- a/src/components/contactform.astro
+++ b/src/components/contactform.astro
@@ -22,6 +22,9 @@ import Button from "./ui/button.astro";
     class="w-full px-4 py-3 border-2 rounded-md border-gray-300 focus:border-gray-600 focus:ring-4 ring-gray-100"
   >
     <option value="">Select Inquiry Type</option>
+    <option value="find-solution">I have a business need — find me a solution or builder</option>
+    <option value="find-project">I'm a developer — connect me with a project or customer</option>
+    <option value="hardware-partner">Hardware OEM — explore platform partnership</option>
     <option value="demo">Request a Demo</option>
     <option value="partnership">Partnership / Business Inquiry</option>
     <option value="developer">Open Source Contributor / Developer</option>
@@ -112,6 +115,9 @@ import Button from "./ui/button.astro";
 
   // Map URL type params to select values
   const typeMapping = {
+    "find-solution": "find-solution",
+    "find-project": "find-project",
+    "hardware-partner": "hardware-partner",
     "demo": "demo",
     "feature": "feature",
     "partnership": "partnership",

--- a/src/components/features.astro
+++ b/src/components/features.astro
@@ -52,10 +52,10 @@ const features = [
 
 <div class="mt-16 md:mt-0">
   <h2 class="text-4xl lg:text-5xl font-bold lg:tracking-tight">
-    Why Choose Atriva?
+    Why Developers Choose Atriva
   </h2>
   <p class="text-lg mt-4 text-slate-600">
-    Six core advantages that make building, scaling, and extending Edge AI with AI agents faster and more reliable.
+    Open source, hardware-agnostic, and built for production — the platform serious edge AI developers reach for.
   </p>
 </div>
 

--- a/src/components/logos.astro
+++ b/src/components/logos.astro
@@ -1,4 +1,5 @@
 ---
+import { Icon } from "astro-icon/components";
 // Logos list (SVGs or PNGs stored in /public/logos)
 const logos = [
   { name: "Docker", src: "/images/logos/Docker.png" },
@@ -64,6 +65,17 @@ const logos = [
         ))}
       </div>
     </div>
+  </div>
+
+  <!-- Quick Start CTA -->
+  <div class="container max-w-screen-xl mx-auto px-4 mt-10 text-center">
+    <a
+      href="/docs"
+      class="inline-flex items-center gap-2 px-6 py-3 bg-[#48A18D] hover:bg-[#3b8675] text-white font-semibold rounded-lg transition-colors"
+    >
+      <Icon name="bx:bx-rocket" class="w-5 h-5" />
+      Quick Start Guide
+    </a>
   </div>
 </section>
 

--- a/src/config/products.ts
+++ b/src/config/products.ts
@@ -48,6 +48,38 @@ export const products: Product[] = [
     status: "ready",
   },
   {
+    id: "atriva-facial-intelligence",
+    name: "Atriva Facial Intelligence",
+    tagline: "High-precision face search and tracking across cameras",
+    description:
+      "Atriva Facial Intelligence is a high-precision face intelligence platfogrm designed for large-scale camera environments. Built for retail, healthcare, and enterprise security teams, it enables fast face search, cross-camera tracking, and incident investigation—entirely on the edge, without cloud dependency.",
+    useCaseIcons: ["bx:bx-camera", "bx:bx-search", "bx:bx-shield-quarter"],
+    features: [
+      "Cross-camera face tracking without enrollment",
+      "Rapid face search across live and recorded video",
+      "Incident investigation in minutes, not hours",
+      "Designed for privacy-aware deployments",
+    ],
+    capabilities: [
+      "High-accuracy face matching with partial occlusion",
+      "Automatic face indexing and clustering",
+      "Track individuals across time and cameras",
+      "Works with existing IP cameras",
+      "Edge-based processing (no cloud required)",
+      "Evidence export and case management",
+    ],
+    appliedTo: [
+      "Retail loss prevention",
+      "Hospital security",
+      "Enterprise investigations",
+      "Public space safety",
+      "Factory staff monitoring",
+    ],
+    image: "/images/products/atriva-facial-intelligence.png",
+    featured: true,
+    status: "ready",
+  },  
+  {
     id: "smart-parking",
     name: "Smart Parking System",
     tagline: "Intelligent parking management with edge AI",
@@ -206,7 +238,7 @@ export const products: Product[] = [
       "Meal delivery operations",
       "Catering services"
     ],
-    status: "coming-soon",
+    status: "ready",
   },
   {
     id: "ai-vision-agent",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,7 +12,9 @@ import HowItWorks from "../components/HowItWorks.astro";
 import AgenticAI from "../components/AgenticAI.astro";
 import UseCases from "../components/UseCases.astro";
 import Screenshots from "../components/Screenshots.astro";
+import WhoWeHelp from "../components/WhoWeHelp.astro";
 import Community from "../components/Community.astro";
+import EcosystemPartners from "../components/EcosystemPartners.astro";
 import BusinessModel from "../components/BusinessModel.astro";
 
 const entry = await getEntryBySlug("pages", "index");
@@ -39,13 +41,13 @@ const { data, body } = entry;
 
   <Container>
     <Hero />
-    <HowItWorks />
+    <WhoWeHelp />
+    <UseCases />
     <AgenticAI />
     <Features />
-    <UseCases />
-    <Screenshots />
-    <Logos />
+    <HowItWorks />
     <Community />
+    <Logos />
     <BusinessModel />
     <Cta />
   </Container>


### PR DESCRIPTION
## Summary

- **New `WhoWeHelp` section** right after the hero — three persona cards (Developer, Customer/SI, Hardware OEM) each with a direct CTA to the contact form with pre-selected inquiry type
- **New `EcosystemPartners` section** — network-first positioning text
- **Section reorder** — use cases and AI value props move up; technical how-to sections move below the fold
- **Section renames** for broader audience clarity (Use Cases → Edge AI in the Real World, etc.)
- **Removed** Screenshots section — redundant with product links in Use Cases
- **Quick Start Guide** button added below hardware logo marquee
- **BusinessModel** visual refresh — white background, solid green cards
- **Contact form** — three new inquiry types wired to persona CTAs
- **Products config** — Atriva Facial Intelligence added; food delivery marked ready

## Test plan

- [ ] Scroll homepage end-to-end — confirm section order and no visual bleed between last three sections
- [ ] Click each card CTA in "Who We Help" — confirm contact form pre-selects the correct inquiry type
- [ ] Click "Quick Start Guide" below logo wall — confirm it routes to /docs
- [ ] Check mobile layout of WhoWeHelp three-card grid
- [ ] Verify no broken imports (Screenshots removed from index.astro but file kept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)