### PR TITLE
feat: improve hero copy, CTAs, and developer card

### DIFF
--- a/src/components/BusinessModel.astro
+++ b/src/components/BusinessModel.astro
@@ -35,7 +35,7 @@ const models = [
         Open Source Business Model
       </div>
       <h2 class="text-4xl lg:text-5xl font-bold lg:tracking-tight text-slate-900">
-        Grow the Edge AI Ecosystem on Atriva
+        Built for Everyone Who Ships Edge AI
       </h2>
       <p class="text-lg mt-4 text-slate-600">
         Whether you're a developer, system integrator, or hardware partner — there's a model here that works for you.

--- a/src/components/WhoWeHelp.astro
+++ b/src/components/WhoWeHelp.astro
@@ -9,6 +9,9 @@ const personas = [
     body: "You have edge AI skills — using your own stack or ours. We connect you with customers who need solutions built and hardware partners who want developers on their platform.",
     cta: "Find a Project",
     href: "/contact?type=find-project",
+    secondaryCta: "Visit GitHub",
+    secondaryHref: "https://github.com/atriva-ai-community",
+    secondaryExternal: true,
   },
   {
     icon: "bx:bx-buildings",
@@ -68,17 +71,30 @@ const personas = [
             {p.body}
           </p>
 
-          <a
-            href={p.href}
-            class={`inline-flex items-center gap-2 px-5 py-2.5 rounded-lg font-semibold text-sm transition-colors self-start ${
-              p.highlight
-                ? "bg-white text-[#48A18D] hover:bg-slate-100"
-                : "bg-[#48A18D] text-white hover:bg-[#3b8675]"
-            }`}
-          >
-            {p.cta}
-            <Icon name="bx:bx-right-arrow-alt" class="w-4 h-4" />
-          </a>
+          <div class="flex flex-col gap-2 self-start">
+            <a
+              href={p.href}
+              class={`inline-flex items-center gap-2 px-5 py-2.5 rounded-lg font-semibold text-sm transition-colors ${
+                p.highlight
+                  ? "bg-white text-[#48A18D] hover:bg-slate-100"
+                  : "bg-[#48A18D] text-white hover:bg-[#3b8675]"
+              }`}
+            >
+              {p.cta}
+              <Icon name="bx:bx-right-arrow-alt" class="w-4 h-4" />
+            </a>
+            {p.secondaryCta && (
+              <a
+                href={p.secondaryHref}
+                target={p.secondaryExternal ? "_blank" : undefined}
+                rel={p.secondaryExternal ? "noopener" : undefined}
+                class="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg font-semibold text-sm border-2 border-[#48A18D] text-[#48A18D] hover:bg-[#48A18D]/10 transition-colors"
+              >
+                <Icon name="bx:bxl-github" class="w-4 h-4" />
+                {p.secondaryCta}
+              </a>
+            )}
+          </div>
         </div>
       ))}
     </div>

--- a/src/components/hero.astro
+++ b/src/components/hero.astro
@@ -23,32 +23,25 @@ import { Icon } from "astro-icon/components";
       <h2 class="text-5xl font-bold text-[#48A18D]">Build, Deploy, and Scale Edge AI Faster</h2>
     </div>
     <p class="text-lg mt-4 text-slate-600 max-w-xl">
-      Building Edge AI apps is complicated—requiring hardware tuning, optimization, deployment pipelines, and expertise across multiple domains. Atriva makes it simple. We provide ready-to-use containers, pre-optimized for your hardware, so you can skip the painful integration work. From setup to scaling, we streamline the entire stack—so you can move faster, cut complexity, and focus on creating impactful solutions.
+      Building Edge AI is hard — hardware tuning, model optimization, deployment pipelines, and deep multi-domain expertise. Atriva takes that complexity off your plate. Whether you're a developer shipping a solution, a business that needs one, or a hardware partner reaching new markets — we provide the platform, the connections, and the pre-built building blocks so everyone in the chain moves faster.
     </p>
     <div class="mt-6 flex flex-col sm:flex-row gap-3">
-      <!--- remove download button for now 
-      <Link
-        href="#"
-        href="https://web3templates.com/templates/astroship-starter-website-template-for-astro"
-        target="_blank"
-        class="flex gap-1 items-center justify-center"
-        rel="noopener">
-        <Icon class="text-white w-5 h-5" name="bx:bxs-cloud-download" />
-
-        Download for Free
-      </Link>
-      -->
       <Link
         size="lg"
-        href="https://github.com/atriva-ai-community"
-        target="_blank"
-        rel="noopener"
+        href="/products"
         class="flex gap-2 items-center justify-center bg-[#48A18D] text-white font-semibold px-6 py-3 rounded-lg hover:bg-[#3b8675] transition"
       >
-        <Icon class="text-white w-4 h-4" name="bx:bxl-github" />
-        Visit GitHub →
+        <Icon class="text-white w-4 h-4" name="bx:bx-grid-alt" />
+        Explore Solutions
       </Link>
-
+      <Link
+        size="lg"
+        href="/contact"
+        class="flex gap-2 items-center justify-center border-2 border-[#48A18D] text-[#48A18D] font-semibold px-6 py-3 rounded-lg hover:bg-[#48A18D]/10 transition"
+      >
+        <Icon class="w-4 h-4" name="bx:bx-message-rounded-dots" />
+        Talk to Us
+      </Link>
     </div>
   </div>
 </main>


### PR DESCRIPTION
## Summary

- Hero: rewrite paragraph to address developers, customers, and OEM partners
- Hero: replace "Visit GitHub" with "Explore Solutions" + "Talk to Us" buttons
- BusinessModel: rename section to "Built for Everyone Who Ships Edge AI"
- WhoWeHelp: add GitHub button under the For Developers card

## Test plan

- [ ] Hero shows two buttons: "Explore Solutions" (green) and "Talk to Us" (outline)
- [ ] "Explore Solutions" routes to /products, "Talk to Us" routes to /contact
- [ ] "For Developers" card in Who We Help shows GitHub button below "Find a Project"
- [ ] BusinessModel section title reads "Built for Everyone Who Ships Edge AI"

🤖 Generated with [Claude Code](https://claude.com/claude-code)