### PR TITLE
feat: reposition site as ecosystem deployment partner, add /solutions page

### DIFF
--- a/src/components/AgenticAI.astro
+++ b/src/components/AgenticAI.astro
@@ -29,7 +29,7 @@ const pillars = [
     <!-- Badge -->
     <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[#48A18D]/10 text-[#48A18D] text-sm font-medium mb-6">
       <Icon name="bx:bx-brain" class="w-4 h-4" />
-      The Hybrid Edge-AI Architecture
+      How It Works
     </div>
 
     <div class="max-w-3xl">

--- a/src/components/UseCases.astro
+++ b/src/components/UseCases.astro
@@ -55,10 +55,10 @@ const cases = [
   <div class="container max-w-screen-xl mx-auto px-4">
     <div class="mt-16 md:mt-0">
       <h2 class="text-4xl lg:text-5xl font-bold lg:tracking-tight">
-        Edge AI in the Real World
+        Deployment Experience
       </h2>
       <p class="text-lg mt-4 text-slate-600 max-w-2xl">
-        From factory floors to retail stores — problems being solved with edge AI today.
+        Examples of Edge AI solutions we have helped design, integrate, and deploy across industries.
       </p>
 
       <div class="grid sm:grid-cols-2 md:grid-cols-3 mt-16 gap-12">
@@ -93,10 +93,10 @@ const cases = [
       <!-- View All Products Link -->
       <div class="mt-12 text-center">
         <a
-          href="/products"
+          href="/solutions"
           class="inline-flex items-center gap-2 text-[#48A18D] hover:text-[#3b8675] font-medium transition-colors"
         >
-          View all products
+          View all solutions
           <Icon name="bx:bx-right-arrow-alt" class="w-5 h-5" />
         </a>
       </div>

--- a/src/components/WhoWeHelp.astro
+++ b/src/components/WhoWeHelp.astro
@@ -3,30 +3,27 @@ import { Icon } from "astro-icon/components";
 
 const personas = [
   {
-    icon: "bx:bx-code-alt",
-    tag: "For Developers",
-    headline: "Find real projects and customers",
-    body: "You have edge AI skills — using your own stack or ours. We connect you with customers who need solutions built and hardware partners who want developers on their platform.",
-    cta: "Find a Project",
-    href: "/contact?type=find-project",
-    secondaryCta: "Visit GitHub",
-    secondaryHref: "https://github.com/atriva-ai-community",
-    secondaryExternal: true,
+    icon: "bx:bx-network-chart",
+    tag: "System Integrators",
+    headline: "Win more AI projects",
+    body: "We provide AI expertise, technology selection, and partner coordination so you can take on edge AI projects with confidence — without building everything from scratch.",
+    cta: "Let's Work Together",
+    href: "/contact?type=find-solution",
   },
   {
     icon: "bx:bx-buildings",
-    tag: "For Customers & System Integrators",
-    headline: "Tell us your problem. We find the solution.",
-    body: "You don't need to know the technology. Tell us the business outcome you need — we match you to a working solution or the right team to build it.",
+    tag: "Enterprise Customers",
+    headline: "Get the right solution, not just software",
+    body: "We help you identify the right technology, assemble the right partners, and deploy a complete edge AI solution — without needing to manage vendors and hardware yourself.",
     cta: "Describe Your Need",
     href: "/contact?type=find-solution",
     highlight: true,
   },
   {
-    icon: "bx:bx-chip",
-    tag: "For Hardware OEMs",
-    headline: "Reach developers who build real products",
-    body: "We work with developers building production edge AI solutions. We help put your hardware in front of the right builders — and the customers who depend on them.",
+    icon: "bx:bx-globe",
+    tag: "Software Partners (ISVs)",
+    headline: "Reach customers you can't reach alone",
+    body: "We open doors to customers you can't reach alone and coordinate the local ecosystem to help deals close. We don't build competing products — we extend your reach.",
     cta: "Explore Partnership",
     href: "/contact?type=hardware-partner",
   },
@@ -37,13 +34,14 @@ const personas = [
   <div class="container max-w-screen-xl mx-auto px-4">
     <div class="text-center max-w-2xl mx-auto mb-14">
       <h2 class="text-4xl lg:text-5xl font-bold lg:tracking-tight text-slate-900">
-        Who We Help
+        Who We Work With
       </h2>
       <p class="text-lg mt-4 text-slate-600">
-        Whether you build software, run a business, or make hardware — we connect you to the right people.
+        We complement your team, your software, and your business — we don't replace them.
       </p>
     </div>
 
+    <!-- Primary audience cards -->
     <div class="grid md:grid-cols-3 gap-8 max-w-6xl mx-auto">
       {personas.map((p) => (
         <div class={`relative flex flex-col rounded-2xl p-8 border transition-all duration-300 ${
@@ -71,32 +69,58 @@ const personas = [
             {p.body}
           </p>
 
-          <div class="flex flex-col gap-2 self-start">
-            <a
-              href={p.href}
-              class={`inline-flex items-center gap-2 px-5 py-2.5 rounded-lg font-semibold text-sm transition-colors ${
-                p.highlight
-                  ? "bg-white text-[#48A18D] hover:bg-slate-100"
-                  : "bg-[#48A18D] text-white hover:bg-[#3b8675]"
-              }`}
-            >
-              {p.cta}
-              <Icon name="bx:bx-right-arrow-alt" class="w-4 h-4" />
-            </a>
-            {p.secondaryCta && (
-              <a
-                href={p.secondaryHref}
-                target={p.secondaryExternal ? "_blank" : undefined}
-                rel={p.secondaryExternal ? "noopener" : undefined}
-                class="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg font-semibold text-sm border-2 border-[#48A18D] text-[#48A18D] hover:bg-[#48A18D]/10 transition-colors"
-              >
-                <Icon name="bx:bxl-github" class="w-4 h-4" />
-                {p.secondaryCta}
-              </a>
-            )}
-          </div>
+          <a
+            href={p.href}
+            class={`inline-flex items-center gap-2 px-5 py-2.5 rounded-lg font-semibold text-sm transition-colors self-start ${
+              p.highlight
+                ? "bg-white text-[#48A18D] hover:bg-slate-100"
+                : "bg-[#48A18D] text-white hover:bg-[#3b8675]"
+            }`}
+          >
+            {p.cta}
+            <Icon name="bx:bx-right-arrow-alt" class="w-4 h-4" />
+          </a>
         </div>
       ))}
     </div>
+
+    <!-- Secondary: Developer row -->
+    <div class="mt-8 max-w-6xl mx-auto border border-slate-200 rounded-2xl px-8 py-6 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 bg-slate-50">
+      <div class="flex items-center gap-4">
+        <div class="w-10 h-10 rounded-xl bg-[#48A18D]/10 flex items-center justify-center flex-shrink-0">
+          <Icon name="bx:bx-code-alt" class="w-5 h-5 text-[#48A18D]" />
+        </div>
+        <div>
+          <p class="font-semibold text-slate-900 text-sm">Individual Developers</p>
+          <p class="text-slate-500 text-sm">Use our open-source building blocks — your stack or ours.</p>
+        </div>
+      </div>
+      <div class="flex items-center gap-3 flex-shrink-0">
+        <a
+          href="https://github.com/atriva-ai-community"
+          target="_blank"
+          rel="noopener"
+          class="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-semibold border-2 border-slate-300 text-slate-700 hover:border-[#48A18D] hover:text-[#48A18D] transition-colors"
+        >
+          <Icon name="bx:bxl-github" class="w-4 h-4" />
+          GitHub
+        </a>
+        <a
+          href="/docs"
+          class="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-semibold border-2 border-slate-300 text-slate-700 hover:border-[#48A18D] hover:text-[#48A18D] transition-colors"
+        >
+          <Icon name="bx:bx-file" class="w-4 h-4" />
+          Docs
+        </a>
+        <a
+          href="/contact?type=find-project"
+          class="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-semibold border-2 border-slate-300 text-slate-700 hover:border-[#48A18D] hover:text-[#48A18D] transition-colors"
+        >
+          <Icon name="bx:bx-briefcase" class="w-4 h-4" />
+          Find a Project
+        </a>
+      </div>
+    </div>
+
   </div>
 </section>

--- a/src/components/hero.astro
+++ b/src/components/hero.astro
@@ -23,12 +23,12 @@ import { Icon } from "astro-icon/components";
       <h2 class="text-5xl font-bold text-[#48A18D]">Build, Deploy, and Scale Edge AI Faster</h2>
     </div>
     <p class="text-lg mt-4 text-slate-600 max-w-xl">
-      Building Edge AI is hard — hardware tuning, model optimization, deployment pipelines, and deep multi-domain expertise. Atriva takes that complexity off your plate. Whether you're a developer shipping a solution, a business that needs one, or a hardware partner reaching new markets — we provide the platform, the connections, and the pre-built building blocks so everyone in the chain moves faster.
+      Getting Edge AI into production requires more than good software — it takes the right hardware, the right partners, and practical deployment experience. Atriva combines technical expertise with an ecosystem of software partners, system integrators, and hardware vendors to help organizations deliver complete Edge AI solutions. We coordinate the pieces so you don't have to.
     </p>
     <div class="mt-6 flex flex-col sm:flex-row gap-3">
       <Link
         size="lg"
-        href="/products"
+        href="/solutions"
         class="flex gap-2 items-center justify-center bg-[#48A18D] text-white font-semibold px-6 py-3 rounded-lg hover:bg-[#3b8675] transition"
       >
         <Icon class="text-white w-4 h-4" name="bx:bx-grid-alt" />

--- a/src/components/logos.astro
+++ b/src/components/logos.astro
@@ -24,8 +24,7 @@ const logos = [
         Built for Your Tools and Hardware
       </h2>
       <p class="mt-4 text-slate-600 max-w-2xl mx-auto">
-        Atriva integrates seamlessly with popular frameworks, hardware, and AI runtimes.
-        You bring your stack — we make it work together.
+        We have practical deployment experience across these hardware platforms, AI runtimes, and development tools.
       </p>
     </div>
   </div>

--- a/src/components/navbar/navbar.astro
+++ b/src/components/navbar/navbar.astro
@@ -14,8 +14,8 @@ const menuitems = [
     path: "/docs",
   },
   {
-    title: "Products",
-    path: "/products",
+    title: "Solutions",
+    path: "/solutions",
   },
   {
     title: "Blog",

--- a/src/components/products/ProductCard.astro
+++ b/src/components/products/ProductCard.astro
@@ -7,46 +7,14 @@ interface Props {
 }
 
 const { product } = Astro.props;
-
-// Determine CTA based on product status
-const isReady = product.status === "ready";
-const ctaText = isReady ? "Request Demo" : "Show Interest";
-const ctaIcon = isReady ? "bx:bx-calendar" : "bx:bx-heart";
-const ctaUrl = isReady 
-  ? `/contact?product=${product.id}` 
-  : `/contact?product=${product.id}&type=feature`;
-
-// Status badge styling
-const statusConfig = {
-  "ready": { label: "Ready to Deploy", bgClass: "bg-emerald-500", textClass: "text-emerald-500" },
-  "coming-soon": { label: "Coming Soon", bgClass: "bg-amber-500", textClass: "text-amber-500" },
-  "planning": { label: "In Planning", bgClass: "bg-slate-400", textClass: "text-slate-400" },
-};
-const status = statusConfig[product.status];
 ---
 
 <div
   class="product-card group relative bg-white rounded-2xl border border-slate-200 p-6 hover:border-[#48A18D]/40 hover:shadow-xl hover:shadow-[#48A18D]/5 transition-all duration-300"
   data-product-id={product.id}
-  data-product-status={product.status}
 >
-  {/* Status Badge */}
-  <div class="absolute -top-3 left-6 flex gap-2">
-    <span class:list={[
-      "text-white text-xs font-semibold px-3 py-1 rounded-full shadow-sm",
-      status.bgClass
-    ]}>
-      {status.label}
-    </span>
-    {product.featured && (
-      <span class="bg-gradient-to-r from-[#48A18D] to-[#3b8675] text-white text-xs font-semibold px-3 py-1 rounded-full shadow-sm">
-        Featured
-      </span>
-    )}
-  </div>
-
   <!-- Use Case Icons -->
-  <div class="flex gap-2 mb-4 mt-2">
+  <div class="flex gap-2 mb-4">
     {product.useCaseIcons.map((icon) => (
       <div class="w-10 h-10 rounded-lg bg-slate-100 group-hover:bg-[#48A18D]/10 flex items-center justify-center transition-colors">
         <Icon name={icon} class="w-5 h-5 text-slate-600 group-hover:text-[#48A18D] transition-colors" />
@@ -54,7 +22,7 @@ const status = statusConfig[product.status];
     ))}
   </div>
 
-  <!-- Product Name -->
+  <!-- Solution Name -->
   <h3 class="text-xl font-bold text-slate-900 mb-2 group-hover:text-[#48A18D] transition-colors">
     {product.name}
   </h3>
@@ -85,16 +53,11 @@ const status = statusConfig[product.status];
       View Details
     </button>
     <a
-      href={ctaUrl}
-      class:list={[
-        "flex-1 px-4 py-2.5 text-sm font-medium rounded-lg transition-colors flex items-center justify-center gap-1.5",
-        isReady 
-          ? "text-white bg-[#48A18D] hover:bg-[#3b8675]" 
-          : "text-slate-700 bg-slate-200 hover:bg-slate-300 border border-slate-300"
-      ]}
+      href={`/contact?product=${product.id}`}
+      class="flex-1 px-4 py-2.5 text-sm font-medium rounded-lg transition-colors flex items-center justify-center gap-1.5 text-white bg-[#48A18D] hover:bg-[#3b8675]"
     >
-      <Icon name={ctaIcon} class="w-4 h-4" />
-      {ctaText}
+      <Icon name="bx:bx-message-rounded-dots" class="w-4 h-4" />
+      Discuss This
     </a>
   </div>
 </div>

--- a/src/config/products.ts
+++ b/src/config/products.ts
@@ -23,7 +23,7 @@ export const products: Product[] = [
   {
     id: "retail-analytics",
     name: "Retail Analytics Suite",
-    tagline: "Real-time customer insights for smarter retail decisions",
+    tagline: "Understand how customers move through your store — and act on it.",
     description:
       "AI-powered retail analytics built for real-world stores. Understand customer flow, optimize layouts, and improve operations using real-time, edge-based insights—without sending video to the cloud.",    
     useCaseIcons: ["bx:bx-store", "bx:bx-user", "bx:bx-line-chart"],
@@ -82,7 +82,7 @@ export const products: Product[] = [
   {
     id: "smart-parking",
     name: "Smart Parking System",
-    tagline: "Intelligent parking management with edge AI",
+    tagline: "Automate parking enforcement and occupancy tracking using cameras you already have.",
     description: "Automate parking operations with license plate recognition, occupancy tracking, and violation detection. Deploy quickly using existing cameras for real-time, reliable enforcement.",
     useCaseIcons: ["bx:bx-car", "bx:bx-camera", "bx:bx-check-shield"],
     features: [
@@ -107,7 +107,7 @@ export const products: Product[] = [
   {
     id: "safety-monitor",
     name: "Workplace Safety Monitor",
-    tagline: "Smart AI safety for a worry-free workforce",
+    tagline: "Enforce safety compliance automatically — without relying on manual inspections.",
     description:
       "Improve workplace safety with automated PPE detection, restricted zone monitoring, and incident alerts. Real-time analysis helps enforce compliance without manual oversight.",
     useCaseIcons: ["bx:bx-hard-hat", "bx:bx-shield-alt-2", "bx:bx-bell"],
@@ -170,7 +170,7 @@ export const products: Product[] = [
   {
     id: "ai-vision-fall-detection",
     name: "AI Vision Fall Detection",
-    tagline: "Zero-blind-spot protection with instant response",
+    tagline: "Detect falls immediately and alert staff — no wearables, no cloud, no delay.",
     description:
       "An AI-powered fall detection system that continuously monitors environments using video analytics to detect falls in real time, trigger immediate alerts, and reduce response time without requiring wearable devices.",
     useCaseIcons: [
@@ -209,7 +209,7 @@ export const products: Product[] = [
   {
     id: "meal-inspection-system",
     name: "Meal Inspection System",
-    tagline: "AI meal checker for zero-mistake orders",
+    tagline: "Verify every order before it leaves the kitchen — automatically.",
     description:
       "An AI-powered meal inspection solution that verifies food orders, detects anomalies, and ensures correct plating before delivery, helping food service operations eliminate mistakes and improve quality control.",
     useCaseIcons: [
@@ -243,7 +243,7 @@ export const products: Product[] = [
   {
     id: "ai-vision-agent",
     name: "AI Vision Agent",
-    tagline: "Give your AI agents eyes at the edge",
+    tagline: "Connect real-time video intelligence to any AI agent or LLM workflow.",
     description:
       "Connect Atriva's real-time video intelligence to any LLM or agentic framework. Atriva observes continuously on-device; your agent reasons only when something matters — keeping costs low, latency minimal, and data private.",
     useCaseIcons: ["bx:bx-bot", "bx:bx-brain", "bx:bx-link"],
@@ -340,9 +340,9 @@ export const products: Product[] = [
 
 export const heroContent = {
   title: "Edge AI Solutions",
-  subtitle: "Built for Real-World Impact",
+  subtitle: "Deployment Experience",
   description:
-    "We're building AI solutions that solve real problems. Some are ready today, others are coming soon—your feedback helps us prioritize what matters most.",
+    "Examples of Edge AI solutions we have helped design, integrate, and deploy. Every project is customized to the customer's environment, hardware, and requirements.",
 };
 
 // Helper functions to filter products by status

--- a/src/pages/solutions.astro
+++ b/src/pages/solutions.astro
@@ -1,0 +1,108 @@
+---
+import Layout from "@/layouts/Layout.astro";
+import Container from "@/components/container.astro";
+import ProductCard from "@/components/products/ProductCard.astro";
+import ProductModal from "@/components/products/ProductModal.astro";
+import { products } from "@/config/products";
+import { Icon } from "astro-icon/components";
+
+const solutionIds = [
+  "retail-analytics",
+  "safety-monitor",
+  "smart-parking",
+  "ai-vision-fall-detection",
+  "meal-inspection-system",
+  "ai-vision-agent",
+];
+
+const solutions = solutionIds
+  .map(id => products.find(p => p.id === id))
+  .filter(Boolean);
+---
+
+<Layout title="Solutions">
+  <!-- Hero Section -->
+  <section class="relative overflow-hidden">
+    <div class="absolute inset-0 bg-gradient-to-tl from-[#48A18D]/15 via-[#48A18D]/5 to-transparent"></div>
+    <div class="absolute bottom-0 right-0 w-[500px] h-[500px] bg-[#48A18D]/10 rounded-full blur-3xl translate-x-1/4 translate-y-1/4"></div>
+
+    <Container>
+      <div class="relative pt-20 pb-16 text-center">
+        <div class="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-[#48A18D]/10 text-[#48A18D] text-sm font-medium mb-6">
+          <Icon name="bx:bx-cube" class="w-4 h-4" />
+          Deployment Experience
+        </div>
+
+        <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold text-slate-900 mb-6 tracking-tight">
+          Edge AI Solutions
+        </h1>
+
+        <p class="text-lg md:text-xl text-slate-600 max-w-2xl mx-auto mb-4">
+          Examples of Edge AI solutions we have helped design, integrate, and deploy. Every project is customized to the customer's environment, hardware, and requirements.
+        </p>
+
+        <!-- ISV partnership note -->
+        <p class="text-sm text-slate-500 max-w-xl mx-auto mb-10">
+          Already have software in one of these areas? We work with existing software partners — we don't require you to use ours. <a href="/contact?type=hardware-partner" class="text-[#48A18D] hover:underline font-medium">Talk to us about partnering →</a>
+        </p>
+
+        <div class="flex flex-col sm:flex-row gap-4 justify-center">
+          <a
+            href="/contact"
+            class="inline-flex items-center justify-center gap-2 px-8 py-4 text-white bg-[#48A18D] hover:bg-[#3b8675] font-semibold rounded-lg transition-colors shadow-lg shadow-[#48A18D]/25"
+          >
+            <Icon name="bx:bx-message-rounded-dots" class="w-5 h-5" />
+            Discuss Your Requirements
+          </a>
+          <a
+            href="/docs"
+            class="inline-flex items-center justify-center gap-2 px-8 py-4 text-slate-700 bg-white hover:bg-slate-50 font-semibold rounded-lg transition-colors border border-slate-200"
+          >
+            <Icon name="bx:bx-book-open" class="w-5 h-5" />
+            Technical Docs
+          </a>
+        </div>
+      </div>
+    </Container>
+  </section>
+
+  <!-- Solutions Grid -->
+  <section class="py-20">
+    <Container>
+      <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6 max-w-6xl mx-auto">
+        {solutions.map((solution) => (
+          <ProductCard product={solution} />
+        ))}
+      </div>
+    </Container>
+  </section>
+
+  <!-- Bottom CTA -->
+  <section class="py-20 bg-slate-50">
+    <Container>
+      <div class="relative rounded-3xl bg-gradient-to-br from-[#48A18D] to-[#3b8675] p-12 md:p-16 text-center overflow-hidden">
+        <div class="absolute inset-0 opacity-10">
+          <div class="absolute top-0 right-0 w-64 h-64 bg-white rounded-full blur-3xl transform translate-x-1/2 -translate-y-1/2"></div>
+          <div class="absolute bottom-0 left-0 w-96 h-96 bg-white rounded-full blur-3xl transform -translate-x-1/2 translate-y-1/2"></div>
+        </div>
+        <div class="relative z-10">
+          <h2 class="text-3xl md:text-4xl font-bold text-white mb-4">
+            Don't see exactly what you need?
+          </h2>
+          <p class="text-white/80 max-w-xl mx-auto mb-8">
+            Most deployments are adapted to the customer's environment. Tell us the business problem and we'll work out the right approach together.
+          </p>
+          <a
+            href="/contact"
+            class="inline-flex items-center justify-center gap-2 px-8 py-4 bg-white text-[#48A18D] font-semibold rounded-lg hover:bg-slate-50 transition-colors"
+          >
+            <Icon name="bx:bx-message-rounded-dots" class="w-5 h-5" />
+            Start a Conversation
+          </a>
+        </div>
+      </div>
+    </Container>
+  </section>
+
+  <ProductModal products={products} />
+</Layout>


### PR DESCRIPTION
## Summary

- **Who We Work With**: restructured to SI / Enterprise Customer / Software Partner (ISV) as primary cards, developer row secondary. ISV card explicitly states "we don't build competing products."
- **Hero paragraph**: rewritten around deployment expertise and ecosystem partnerships, not developer tooling
- **New `/solutions` page**: replaces `/products` — 6 curated solutions, no status badges, problem-first taglines, ISV partnership note at the top
- **ProductCard**: status/featured badges removed, single "Discuss This" CTA for all cards
- **Navbar**: "Products" → "Solutions"
- **Deployment Experience**: UseCases section reframed as track record, not product catalogue
- **Logos subtitle**: "practical deployment experience across these ecosystems" — credibility, not product claim
- **Products config**: all 6 taglines rewritten as business problems

## Test plan

- [ ] Homepage: Who We Work With cards show SI / Enterprise / ISV in correct order
- [ ] Developer secondary row visible below cards with GitHub, Docs, Find a Project links
- [ ] "Explore Solutions" hero button routes to /solutions
- [ ] /solutions shows exactly 6 cards with no status badges
- [ ] ISV note visible on /solutions page with partner link
- [ ] "Discuss This" CTA on each card routes to /contact with product param
- [ ] Navbar "Solutions" link works
- [ ] /products still exists (old page kept, not deleted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)